### PR TITLE
remove inappropriate acronym

### DIFF
--- a/content/de/index.html
+++ b/content/de/index.html
@@ -60,7 +60,6 @@ keywords:
     <div class="col-md-4">
       <h2>Popular OSI Acronyms (Layer 1-7)</h2>
       <ul class="big">
-        <li>All Prostitutes Seem To Need Double Penetration</li>
         <li>All People Seem To Need Data Protection</li>
         <li>All Presidents Say They Never Did Pot</li>
         <li>All People Say They Never Download Porn</li>

--- a/content/index.html
+++ b/content/index.html
@@ -60,7 +60,6 @@ keywords:
     <div class="col-md-4">
       <h2>Popular OSI Acronyms (Layer 1-7)</h2>
       <ul class="big">
-        <li>All Prostitutes Seem To Need Double Penetration</li>
         <li>All People Seem To Need Data Protection</li>
         <li>All Presidents Say They Never Did Pot</li>
         <li>All People Say They Never Download Porn</li>


### PR DESCRIPTION
The website is useful as a reference for students to explain and illustrate the OSI model. This oddly explicit acronym makes it unsuitable to be linked to in classroom materials, however, and feels quite unnecessary given that many other, more innocuous acronyms are given.